### PR TITLE
OWC-45 change textlabel 'OpenWoo' given by rest endpoint to Woo-verzoek

### DIFF
--- a/src/blocks/woo-portal/search/assets/scripts/vue/TheFilters.vue
+++ b/src/blocks/woo-portal/search/assets/scripts/vue/TheFilters.vue
@@ -61,7 +61,7 @@ const onChange = () => {
 				v-model="selected"
 				@change="onChange"
 			/>
-			{{ filter.label }}
+			{{ 'OpenWOO' === filter.label ? 'Woo-verzoek' : filter.label }}
 		</label>
 	</fieldset>
 </template>

--- a/src/blocks/woo-portal/search/assets/scripts/vue/TheResult.vue
+++ b/src/blocks/woo-portal/search/assets/scripts/vue/TheResult.vue
@@ -98,8 +98,7 @@ const postTypeLabel = computed(() => {
 	if (!item) {
 		return null;
 	}
-
-	return item.label;
+	return 'OpenWOO' === item.label ? 'Woo-verzoek' : item.label;
 });
 
 /**


### PR DESCRIPTION
 Change textlabel 'OpenWoo' given by rest endpoint to Woo-verzoek.
https://acato-nl.atlassian.net/browse/OWC-45

@richardkorthuis this label comes with the filters from the rest endpoint, its the posttype->label->name which I don't think we can change? So i'm altering it in the FE.