### PR TITLE
correctly add custom category to core categories

### DIFF
--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -55,12 +55,15 @@ class Frontend {
 	 */
 	public function register_custom_block_category( $categories ) {
 
-		return [
-			[
-				'slug'  => 'woo-portal-plugin',
-				'title' => __( 'WOO Portal Blocks', 'woo-portal-plugin' ),
-			],
-		];
+        $custom_block = array(
+            'slug'  => 'woo-portal-plugin',
+            'title' => __( 'WOO Portal Blocks', 'woo-portal-plugin' ),
+        );
+
+        // move our custom category to the front of the categories array.
+        array_unshift($categories, $custom_block);
+
+        return $categories;
 	}
 
 	/**


### PR DESCRIPTION
The registration of the custom category was causing other core block categories to disappear and the core blocks to be uncategorised. Fixes all category registration.